### PR TITLE
Add callback to add dynamic properties after navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,26 @@ const myRoute = {
 
 Note that the properties `event`, `content-name` and `content-view-name` are always overridden.
 
+### Passing dynamic properties with page view events
+
+If you need to pass dynamic properties as parto of your page views, you can set a callback that derives the custom data after navigation.
+
+Example:
+
+```js
+createGtm({
+  // ...other options
+  vueRouter: router,
+  vueRouterAdditionalEventData: () => ({
+    someComputedProperty: computeProperty()
+  })
+});
+```
+
+> This computes and sends the property `someComputedProperty` as part of your page view event after every navigation.
+
+Note that a property with the same name on route level will override this.
+
 ## Using with composition API
 
 In order to use this plugin with composition API (inside your `setup` method), you can just call the custom composable `useGtm`.

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Note that the properties `event`, `content-name` and `content-view-name` are alw
 
 ### Passing dynamic properties with page view events
 
-If you need to pass dynamic properties as parto of your page views, you can set a callback that derives the custom data after navigation.
+If you need to pass dynamic properties as part of your page views, you can set a callback that derives the custom data after navigation.
 
 Example:
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,10 @@ export interface VueGtmUseOptions extends GtmSupportOptions {
   /**
    * Derive additional event data after navigation.
    */
-  vueRouterAdditionalEventData?: (to: RouteLocationNormalized, from: RouteLocationNormalized) => Record<string, any>;
+  vueRouterAdditionalEventData?: (
+    to: RouteLocationNormalized,
+    from: RouteLocationNormalized
+  ) => Record<string, any> | Promise<Record<string, any>>;
   /**
    * Don't trigger events for specified router names.
    */
@@ -108,7 +111,7 @@ async function initVueRouterGuard(
     return;
   }
 
-  vueRouter.afterEach((to, from, failure) => {
+  vueRouter.afterEach(async (to, from, failure) => {
     // Ignore some routes
     if (
       typeof to.name !== 'string' ||
@@ -132,7 +135,7 @@ async function initVueRouterGuard(
     }
 
     const additionalEventData: Record<string, any> = {
-      ...deriveAdditionalEventData(to, from),
+      ...(await deriveAdditionalEventData(to, from)),
       ...(to.meta?.gtmAdditionalEventData as Record<string, any>)
     };
     const baseUrl: string = vueRouter.options?.history?.base ?? '';

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,10 @@ export interface VueGtmUseOptions extends GtmSupportOptions {
    */
   vueRouter?: Router;
   /**
+   * Derive additional event data after navigation.
+   */
+  vueRouterAdditionalEventData?: (to: RouteLocationNormalized, from: RouteLocationNormalized) => Record<string, any>;
+  /**
    * Don't trigger events for specified router names.
    */
   ignoredViews?: string[] | ((to: RouteLocationNormalized, from: RouteLocationNormalized) => boolean);
@@ -41,7 +45,13 @@ function install(app: App, options: VueGtmUseOptions = { id: '' }): void {
   if (gtmPlugin.isInBrowserContext()) {
     // Handle vue-router if defined
     if (options.vueRouter) {
-      void initVueRouterGuard(app, options.vueRouter, options.ignoredViews, options.trackOnNextTick);
+      void initVueRouterGuard(
+        app,
+        options.vueRouter,
+        options.ignoredViews,
+        options.trackOnNextTick,
+        options.vueRouterAdditionalEventData
+      );
     }
 
     // Load GTM script when enabled
@@ -81,12 +91,14 @@ function install(app: App, options: VueGtmUseOptions = { id: '' }): void {
  * @param vueRouter The Vue router instance to attach the guard.
  * @param ignoredViews An array of route name that will be ignored.
  * @param trackOnNextTick Whether or not to call `trackView` in `Vue.nextTick`.
+ * @param deriveAdditionalEventData Callback to derive additional event data.
  */
 async function initVueRouterGuard(
   app: App,
   vueRouter: Exclude<VueGtmUseOptions['vueRouter'], undefined>,
   ignoredViews: VueGtmUseOptions['ignoredViews'] = [],
-  trackOnNextTick: VueGtmUseOptions['trackOnNextTick']
+  trackOnNextTick: VueGtmUseOptions['trackOnNextTick'],
+  deriveAdditionalEventData: VueGtmUseOptions['vueRouterAdditionalEventData'] = () => ({})
 ): Promise<void> {
   let vueRouterModule: typeof import('vue-router');
   try {
@@ -119,7 +131,10 @@ async function initVueRouterGuard(
       }
     }
 
-    const additionalEventData: Record<string, any> = (to.meta?.gtmAdditionalEventData as Record<string, any>) ?? {};
+    const additionalEventData: Record<string, any> = {
+      ...deriveAdditionalEventData(to, from),
+      ...(to.meta?.gtmAdditionalEventData as Record<string, any>)
+    };
     const baseUrl: string = vueRouter.options?.history?.base ?? '';
     let fullUrl: string = baseUrl;
     if (!fullUrl.endsWith('/')) {

--- a/tests/vue-helper.ts
+++ b/tests/vue-helper.ts
@@ -1,4 +1,6 @@
 import { App, createApp, defineComponent } from 'vue';
+import type { Router, RouteRecordRaw } from 'vue-router';
+import { createMemoryHistory, createRouter } from 'vue-router';
 
 export function appendAppDivToBody(): void {
   const appDiv: HTMLDivElement = document.createElement('div');
@@ -17,6 +19,24 @@ export function createAppWithComponent() {
   });
   const app: App<Element> = createApp(appComponent);
   return { app, component: appComponent };
+}
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type, @typescript-eslint/explicit-module-boundary-types
+export function createAppWithRouter(routes: RouteRecordRaw[]) {
+  const router: Router = createRouter({
+    history: createMemoryHistory(),
+    routes
+  });
+  // eslint-disable-next-line @typescript-eslint/typedef
+  const appComponent = defineComponent({
+    name: 'App',
+    render() {
+      return null;
+    }
+  });
+  const app: App<Element> = createApp(appComponent);
+  app.use(router);
+  return { app, router };
 }
 
 export function resetHtml(): void {

--- a/tests/vue-use.test.ts
+++ b/tests/vue-use.test.ts
@@ -1,6 +1,12 @@
 import type { DataLayerObject } from '../src/index';
 import { createGtm, GtmPlugin as VueGtmPlugin } from '../src/index';
-import { appendAppDivToBody, createAppWithComponent, resetDataLayer, resetHtml } from './vue-helper';
+import {
+  appendAppDivToBody,
+  createAppWithComponent,
+  createAppWithRouter,
+  resetDataLayer,
+  resetHtml
+} from './vue-helper';
 
 describe('Vue.use', () => {
   afterEach(() => {
@@ -258,5 +264,180 @@ describe('Vue.use', () => {
         })
       ])
     );
+  });
+
+  describe('router', () => {
+    test('should add additional event after navigation', async () => {
+      appendAppDivToBody();
+      const { app, router } = createAppWithRouter([
+        {
+          name: 'Home',
+          path: '/',
+          component: {
+            template: '<div>Home</div>'
+          },
+          meta: {
+            gtmAdditionalEventData: {
+              someProperty: 'home-value'
+            }
+          }
+        },
+        {
+          name: 'About',
+          path: '/about',
+          component: {
+            template: '<div>About</div>'
+          },
+          meta: {
+            gtmAdditionalEventData: {
+              someProperty: 'about-value'
+            }
+          }
+        }
+      ]);
+      app
+        .use(
+          createGtm({
+            id: 'GTM-DEMO',
+            vueRouter: router
+          })
+        )
+        .mount('#app');
+      await router.push('/about');
+      expect(window['dataLayer']).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            event: 'gtm.js',
+            'gtm.start': expect.any(Number)
+          }),
+          expect.objectContaining({
+            'content-name': '/',
+            'content-view-name': 'Home',
+            event: 'content-view',
+            someProperty: 'home-value'
+          }),
+          expect.objectContaining({
+            'content-name': '/about',
+            'content-view-name': 'About',
+            event: 'content-view',
+            someProperty: 'about-value'
+          })
+        ])
+      );
+    });
+
+    test('should derive additional event data after navigation', async () => {
+      appendAppDivToBody();
+      const { app, router } = createAppWithRouter([
+        {
+          name: 'Home',
+          path: '/',
+          component: {
+            template: '<div>Home</div>'
+          }
+        },
+        {
+          name: 'About',
+          path: '/about',
+          component: {
+            template: '<div>About</div>'
+          }
+        }
+      ]);
+      app
+        .use(
+          createGtm({
+            id: 'GTM-DEMO',
+            vueRouter: router,
+            vueRouterAdditionalEventData: () => ({
+              someProperty: 'some-value'
+            })
+          })
+        )
+        .mount('#app');
+      await router.push('/about');
+      expect(window['dataLayer']).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            event: 'gtm.js',
+            'gtm.start': expect.any(Number)
+          }),
+          expect.objectContaining({
+            'content-name': '/',
+            'content-view-name': 'Home',
+            event: 'content-view',
+            someProperty: 'some-value'
+          }),
+          expect.objectContaining({
+            'content-name': '/about',
+            'content-view-name': 'About',
+            event: 'content-view',
+            someProperty: 'some-value'
+          })
+        ])
+      );
+    });
+
+    test('should override derived additional event data with route level event data', async () => {
+      appendAppDivToBody();
+      const { app, router } = createAppWithRouter([
+        {
+          name: 'Home',
+          path: '/',
+          component: {
+            template: '<div>Home</div>'
+          },
+          meta: {
+            gtmAdditionalEventData: {
+              someProperty: 'home-value'
+            }
+          }
+        },
+        {
+          name: 'About',
+          path: '/about',
+          component: {
+            template: '<div>About</div>'
+          },
+          meta: {
+            gtmAdditionalEventData: {
+              someProperty: 'about-value'
+            }
+          }
+        }
+      ]);
+      app
+        .use(
+          createGtm({
+            id: 'GTM-DEMO',
+            vueRouter: router,
+            vueRouterAdditionalEventData: () => ({
+              someProperty: 'some-value'
+            })
+          })
+        )
+        .mount('#app');
+      await router.push('/about');
+      expect(window['dataLayer']).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            event: 'gtm.js',
+            'gtm.start': expect.any(Number)
+          }),
+          expect.objectContaining({
+            'content-name': '/',
+            'content-view-name': 'Home',
+            event: 'content-view',
+            someProperty: 'home-value'
+          }),
+          expect.objectContaining({
+            'content-name': '/about',
+            'content-view-name': 'About',
+            event: 'content-view',
+            someProperty: 'about-value'
+          })
+        ])
+      );
+    });
   });
 });


### PR DESCRIPTION
Closes #110 

This PR adds the ability to define a callback to dynamically compute custom properties to add to the page view event after navigation.