### PR TITLE
add: README hint use source to add own URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ app.use(
       gtm_preview: 'env-4',
       gtm_cookies_win: 'x',
     },
+    source: 'https:/customurl.com/gtm.js' , //Add your own serverside GTM script 
     defer: false, // Script can be set to `defer` to speed up page load at the cost of less accurate results (in case visitor leaves before script is loaded, which is unlikely but possible). Defaults to false, so the script is loaded `async` by default
     compatibility: false, // Will add `async` and `defer` to the script tag to not block requests for old browsers that do not support `async`
     nonce: '2726c7f26c', // Will add `nonce` to the script tag


### PR DESCRIPTION
added source hint to add own serverside GTM script. It was kinda a pain fiding that 