### PR TITLE
Fix: return gtmPlugin from app context

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import type {
 } from '@gtm-support/core';
 import { GtmSupport as GtmPlugin, loadScript } from '@gtm-support/core';
 import type { App, Plugin } from 'vue';
-import { nextTick } from 'vue';
+import { nextTick, getCurrentInstance } from 'vue';
 import type {
   ErrorTypes,
   NavigationFailure,
@@ -240,5 +240,6 @@ export default _default;
  * @returns The Vue GTM instance if the it was installed, otherwise `undefined`.
  */
 export function useGtm(): GtmPlugin | undefined {
-  return gtmPlugin;
+  const app = getCurrentInstance()?.appContext?.app;
+  return app?.config?.globalProperties?.$gtm;
 }


### PR DESCRIPTION
I have a problem with Vite inline, which in production mode just copies the `useGtm` function wholesale to the calling file, without copying the scope. This fix solves that problem, since it always fetches the gtm instance from the vue app context