### PR TITLE
Update $gtm global property augmentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "vue-router": "^4.2.5"
   },
   "peerDependencies": {
-    "vue": ">= 3.2.0 < 4.0.0"
+    "vue": ">= 3.2.26 < 4.0.0"
   },
   "peerDependenciesMeta": {
     "vue-router": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -239,7 +239,6 @@ export default _default;
  * @returns The Vue GTM instance if the it was installed, otherwise `undefined`.
  */
 export function useGtm(): GtmPlugin | undefined {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
   return (
     getCurrentInstance()?.appContext?.app?.config?.globalProperties?.$gtm ??
     gtmPlugin

--- a/src/index.ts
+++ b/src/index.ts
@@ -199,8 +199,7 @@ export function createGtm(options: VueGtmUseOptions): VueGtmPlugin {
   return { install: (app: App) => install(app, options) };
 }
 
-// @ts-expect-error: assume that `vue` already brings this dependency
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   // eslint-disable-next-line jsdoc/require-jsdoc
   export interface ComponentCustomProperties {
     /**


### PR DESCRIPTION
Fixes #464. 

`@ts-expect-error` no longer needed 🎉 .

I updated `vue` peer dependency to 3.2.26 as discussed but not sure from where this exact version number is coming from to be honest. Should we just leave it at 3.2.0?